### PR TITLE
json_encode fix & parameters type passed to the view.

### DIFF
--- a/src/classes/SetteeDatabase.class.php
+++ b/src/classes/SetteeDatabase.class.php
@@ -376,4 +376,34 @@ class SetteeDatabase {
 
     return $ret['decoded'];
   }
+  
+  /**
+   * Modify multiple documents with single request.
+   * 
+   * As an param this function takes an array of documents
+   * in specyfic format(@see CouchDB docs - http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API).
+   * If no docs key is specified this function 
+   * will add it to keep consistency with CouchDB.
+   *
+   * @param array $docs
+   * @return array
+   */
+  public function bulk_update(array $docs)
+  {
+      if(!array_key_exists('docs', $docs)) {
+          if(array_key_exists('all_or_nothing', $docs)) {
+              $docs = array(
+                  'all_or_nothing' => $docs['all_or_nothing'],
+                  'docs' => $docs
+              );
+              unset($docs['docs']['all_or_nothing']);
+          }
+          $docs = array('docs' => $docs);
+      }
+      
+      $full_uri = $this->dbname . "/_bulk_docs";
+      $ret = $this->rest_client->http_request('POST', $full_uri, json_encode($docs));
+      
+      return $ret['decoded'];
+  }
 }

--- a/src/classes/SetteeDatabase.class.php
+++ b/src/classes/SetteeDatabase.class.php
@@ -332,14 +332,15 @@ class SetteeDatabase {
    * @param array $view_params
    * @return object
    */
-  public function get_view_extended($design_doc, $view_name = FALSE, $start_key = FALSE, $end_key = FALSE, array $view_params = array())
+  public function get_view_extended($design_doc, $view_name = FALSE, $start_key = FALSE, $end_key = FALSE
+          , array $view_params = array(), $suppressPost = FALSE)
   {
     // encode view parameters
     foreach($view_params as $key => &$val) {
         $val = json_encode($val);
     }
     // prepare keys array as param
-    if(is_array($start_key)) {
+    if(is_array($start_key) && !$suppressPost) {
         if(!array_key_exists('keys', $start_key)) {
             $start_key = array('keys' => $start_key);
         }

--- a/src/classes/SetteeDatabase.class.php
+++ b/src/classes/SetteeDatabase.class.php
@@ -334,6 +334,10 @@ class SetteeDatabase {
    */
   public function get_view_extended($design_doc, $view_name = FALSE, $start_key = FALSE, $end_key = FALSE, array $view_params = array())
   {
+    // encode view parameters
+    foreach($view_params as $key => &$val) {
+        $val = json_encode($val);
+    }
     // prepare keys array as param
     if(is_array($start_key)) {
         if(!array_key_exists('keys', $start_key)) {
@@ -346,7 +350,7 @@ class SetteeDatabase {
             $data_json = json_encode($start_key);
         }
         
-        $query_string = !empty($view_params) ? '?' . http_build_query($view_params) : '';
+        $query_string = !empty($view_params) ? '?' . urldecode(http_build_query($view_params)) : '';
         if($design_doc == FALSE) {
             // case when we requesting _all_docs
             $ret = $this->rest_client->http_request('POST',
@@ -358,13 +362,13 @@ class SetteeDatabase {
         }
     } else {
         if($start_key && !$end_key) {
-            $view_params['key'] = $start_key;
+            $view_params['key'] = json_encode($start_key);
         } else if($start_key && $end_key) {
-            $view_params['startkey'] = $start_key;
-            $view_params['endkey'] = $end_key;
+            $view_params['startkey'] = json_encode($start_key);
+            $view_params['endkey'] = json_encode($end_key);
         }
         
-        $query_string = !empty($view_params) ? '?' . http_build_query($view_params) : '';
+        $query_string = !empty($view_params) ? '?' . urldecode(http_build_query($view_params)) : '';
         $full_uri = $this->dbname . "/" .  $this->safe_urlencode('_design/' . $design_doc . '/_view/' . $view_name) . $query_string;
         $ret = $this->rest_client->http_request('GET', $full_uri);
     }

--- a/src/classes/SetteeDatabase.class.php
+++ b/src/classes/SetteeDatabase.class.php
@@ -98,8 +98,11 @@ class SetteeDatabase {
     }
     
     $full_uri = $this->dbname . "/" . $this->safe_urlencode($id);
-    $document_json = json_encode($document, JSON_NUMERIC_CHECK);
-    
+    if(version_compare(PHP_VERSION, '5.3.3') >= 0) {
+        $document_json = json_encode($document, JSON_NUMERIC_CHECK);
+    } else {
+        $document_json = json_encode($document);
+    }
     $ret = $this->rest_client->http_put($full_uri, $document_json);
 
     $document->_id = $ret['decoded']->id;

--- a/src/classes/SetteeDatabase.class.php
+++ b/src/classes/SetteeDatabase.class.php
@@ -255,15 +255,14 @@ class SetteeDatabase {
     $id = "_design/" . urlencode($design_doc);
     $view_name = urlencode($view_name);
     $id .= "/_view/$view_name";
-
     $data = array();
     if (!empty($key)) {
-      if (is_string($key)) {
-        $data = "key=" . '"' . $key . '"';
+      if (!is_array($key)) {
+        $data = "key=" . $key;
       }
-      elseif (is_array($key)) {
+      else {
         list($startkey, $endkey) = $key;
-        $data = "startkey=" . '"' . $startkey . '"&' . "endkey=" . '"' . $endkey . '"';
+        $data = "startkey=" . $startkey . '&' . "endkey=" . $endkey;
       }
 
       if ($descending) {

--- a/src/classes/SetteeRestClient.class.php
+++ b/src/classes/SetteeRestClient.class.php
@@ -148,11 +148,15 @@ class SetteeRestClient {
    * @return
    *  an array containing json and decoded versions of the response.
    */
-  private function http_request($http_method, $uri, $data = array()) {
+  public function http_request($http_method, $uri, $data = array()) {
     $data = (is_array($data)) ? http_build_query($data) : $data;
 
     if (!empty($data)) {
-      curl_setopt($this->curl, CURLOPT_HTTPHEADER, array('Content-Length: ' . strlen($data)));
+      // header Content-Length is optional
+      curl_setopt($this->curl, CURLOPT_HTTPHEADER, array(
+          'Content-Type:application/json',
+          'Content-Length:' . strlen($data)
+          ));
       curl_setopt($this->curl, CURLOPT_POSTFIELDS, $data);
     }
 


### PR DESCRIPTION
Hi,
I've added two fixes for your library. One of them is releated to param passed to json_encode function(JSON_NUMERIC_CHECK). This parameter is available since PHP 5.3.3. Before that version, json_encode returns NULL.

Second one is fixing types error while passing params to the view. Emmiting number as a key won't work with the original code(numbers are treated as strings).

Best regards,
Paul.
